### PR TITLE
Add support for new GraalVM community builds

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ installer() {
   local tmp_download_dir=$(mktemp -d -t graalvm_XXXXXXX)
 
   if [ "version" != "${install_type}" ]; then
-    echo "The asdf-graalvm plugin only supports intalling official"
+    echo "The asdf-graalvm plugin only supports installing official"
     echo "binary releases as built by the graal team."
     echo "If you want to install another version from source, see:"
     echo "https://github.com/oracle/graal/"
@@ -87,10 +87,19 @@ version_is_one() {
   test "$major_version" -eq 1 
 }
 
+version_is_ce_build() {
+  local version=$1
+  echo "$version" | grep -q -- "^.*-java\d\+$"
+}
+
 download_url() {
   local version=$1
   local variant=$(get_variant $version)
-  if version_is_one $version; then
+  if version_is_ce_build $version; then
+    local graalvm_version=$(echo $version | cut -f1 -d-)
+    local java_version=$(echo $version | cut -f2 -d-)
+    echo "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${graalvm_version}/graalvm-ce-${java_version}-${variant}-${graalvm_version}.tar.gz"
+  elif version_is_one $version; then
     echo "https://github.com/oracle/graal/releases/download/vm-${version}/graalvm-ce-${version}-${variant}.tar.gz"
   else
     echo "https://github.com/oracle/graal/releases/download/vm-${version}/graalvm-ce-${variant}-${version}.tar.gz"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,2 +1,10 @@
 #!/usr/bin/env bash
-git ls-remote --tags --refs https://github.com/oracle/graal "vm-*" | grep -v "enterprise" | sed 's;^.*refs/tags/vm-\(.*\)$;\1;' | xargs echo
+cmd="curl -s"
+if [ -n "$GITHUB_API_TOKEN" ]; then
+ cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+fi
+
+(
+  $cmd 'https:///api.github.com/repos/oracle/graal/releases' | jq -r 'sort_by(.created_at) | .[] | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name | ltrimstr("vm-")'
+  $cmd 'https:///api.github.com/repos/graalvm/graalvm-ce-builds/releases' | jq -r 'sort_by(.created_at) | .[] | . + {"java": ["java8", "java11"]} | select (.prerelease == false) | select (.tag_name | contains("vm-")) | select (.assets | length > 0) | .tag_name + "-" + .java[]| ltrimstr("vm-")'
+) | xargs echo


### PR DESCRIPTION
Starting with GraalVM 19.3.0, Oracle and the GraalVM team started putting binary releases into a new GitHub organization and repository.

This change set adds support for the new download location and for the different Java versions by GraalVM (Java 8 and Java 11).

Closes #5