### PR TITLE
Add GitHub Actions workflow to replace Travis CI

### DIFF
--- a/.github/workflows/plugin-test.yaml
+++ b/.github/workflows/plugin-test.yaml
@@ -1,0 +1,17 @@
+name: plugin-test
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macOS-latest']
+    env:
+      GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided
+    steps:
+      - name: asdf_plugin_test
+        uses: asdf-vm/actions/plugin-test@v1.0.0
+        with:
+          command: "polyglot --version"


### PR DESCRIPTION
GitHub Actions are better integrated with GitHub than Travis CI and are currently executing the test(s) faster.

Example: https://github.com/joschi/asdf-graalvm/commit/3674304d1d01ad180d7b2ed14077dbb15fc300c2/checks?check_suite_id=358504922