### PR TITLE
Fix grep for new community builds

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -89,7 +89,7 @@ version_is_one() {
 
 version_is_ce_build() {
   local version=$1
-  echo "$version" | grep -q -- "^.*-java\d\+$"
+  echo "$version" | grep -q -P "^.*-java\d+$"
 }
 
 download_url() {


### PR DESCRIPTION
The grep command did not specify to use perl regex. This caused it to
fail on some machines and not match versions of the new community build.