### PR TITLE
Fix grep for community builds on macos

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -89,7 +89,7 @@ version_is_one() {
 
 version_is_ce_build() {
   local version=$1
-  echo "$version" | grep -q -P "^.*-java\d+$"
+  echo "$version" | grep -q -E "^.*-java\d+$"
 }
 
 download_url() {


### PR DESCRIPTION
macOS grep does not support the -P option, but the "extended" regexp mode seems to be enough for matching the CE version numbers:

> asdf list all graalvm | grep -E "^.*-java\d+$"
19.3.0-java8
19.3.0-java11
19.3.0.2-java8
19.3.0.2-java11
19.3.1-java8
19.3.1-java11